### PR TITLE
feat: add delete consent schema

### DIFF
--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -70,6 +70,11 @@ const SERVICE_REGISTRATION = Joi.object({
   eventsURI: Joi.string().uri().required()
 })
 
+const DELETE_CONSENT = Joi.object({
+  ...JWT_DEFAULTS,
+  type: 'DELETE_CONSENT',
+  sub: Joi.string().required()
+})
 // device -> operator
 const ACCOUNT_REGISTRATION = Joi.object({
   ...JWT_DEFAULTS,
@@ -314,7 +319,8 @@ const deviceSchemas = [
   LOGIN_RESPONSE,
   RECIPIENTS_READ_REQUEST,
   RECIPIENTS_READ_RESPONSE,
-  RECIPIENTS_WRITE
+  RECIPIENTS_WRITE,
+  DELETE_CONSENT
 ]
 
 module.exports = {
@@ -342,5 +348,6 @@ module.exports = {
   RECIPIENTS_READ_REQUEST,
   RECIPIENTS_READ_RESPONSE,
   RECIPIENTS_WRITE,
-  SERVICE_REGISTRATION
+  SERVICE_REGISTRATION,
+  DELETE_CONSENT
 }

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -300,8 +300,8 @@ const RECIPIENTS_WRITE = Joi.object({
   sub: Joi.string().uuid({ version: 'uuidv4' }).required(), // connection id
   paths: Joi.array().items(Joi.object({
     ...CONTENT_PATH,
-    recipients: Joi.array().items(RECIPIENT).min(1)
-  })).min(1)
+    recipients: Joi.array().items(RECIPIENT).min(1).required()
+  })).min(1).required()
 }).required()
 
 // Schemas used from mobile device allowing jwk in payload

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -159,7 +159,7 @@ const PERMISSION_REQUEST = Joi.object({
 const CONNECTION_REQUEST = Joi.object({
   ...JWT_DEFAULTS,
   type: 'CONNECTION_REQUEST',
-  permissions: PERMISSION_REQUEST_ARRAY.min(1).optional(),
+  permissions: PERMISSION_REQUEST_ARRAY.min(1),
   sid: Joi.string().uuid({ version: 'uuidv4' }).required(),
   displayName: Joi.string().required(),
   description: Joi.string().required(),
@@ -173,10 +173,9 @@ const CONNECTION = Joi.object({
   sid: Joi.string().required(),
   sub: Joi.string().uuid({ version: 'uuidv4' }).required(),
   permissions: Joi.object({
-    approved: PERMISSION_ARRAY.min(1).optional(),
-    denied: Joi.array().items(PERMISSION_DENIED)
-      .min(1).optional()
-  }).optional()
+    approved: PERMISSION_ARRAY.min(1),
+    denied: Joi.array().items(PERMISSION_DENIED).min(1)
+  })
 }).required()
 
 // device -> operator
@@ -228,9 +227,9 @@ const DATA_READ_REQUEST = Joi.object({
   type: 'DATA_READ_REQUEST',
   sub: Joi.string().uuid({ version: 'uuidv4' }).required(), // connection id
   paths: Joi.array().items(Joi.object({
-    domain: Joi.string().uri().optional(),
-    area: Joi.string().optional()
-  })).min(1).optional()
+    domain: Joi.string().uri(),
+    area: Joi.string()
+  })).min(1)
 }).required()
 
 const DATA_READ_RESPONSE = Joi.object({
@@ -239,14 +238,14 @@ const DATA_READ_RESPONSE = Joi.object({
   sub: Joi.string().uuid({ version: 'uuidv4' }).required(), // connection id
   paths: Joi.array().items(Joi.object({
     ...CONTENT_PATH,
-    data: JWE.optional(),
+    data: JWE,
     error: Joi.object({
       message: Joi.string().required(),
-      status: Joi.number().integer().min(400).max(599).optional(),
-      code: Joi.string().optional(),
-      stack: Joi.string().optional()
+      status: Joi.number().integer().min(400).max(599),
+      code: Joi.string(),
+      stack: Joi.string()
     })
-  })).min(1).optional()
+  })).min(1)
 })
 
 // service -> operator
@@ -256,8 +255,8 @@ const DATA_WRITE = Joi.object({
   sub: Joi.string().uuid({ version: 'uuidv4' }).required(), // connection id
   paths: Joi.array().items(Joi.object({
     ...CONTENT_PATH,
-    data: JWE.optional()
-  })).min(1).optional()
+    data: JWE
+  })).min(1)
 }).required()
 
 // app -> operator
@@ -267,7 +266,7 @@ const RECIPIENTS_READ_REQUEST = Joi.object({
   sub: Joi.string().uuid({ version: 'uuidv4' }).required(), // connection id
   paths: Joi.array().items(Joi.object({
     ...CONTENT_PATH
-  })).min(1).optional()
+  })).min(1)
 }).required()
 
 const RECIPIENT = Joi.object({
@@ -284,14 +283,14 @@ const RECIPIENTS_READ_RESPONSE = Joi.object({
   sub: Joi.string().uuid({ version: 'uuidv4' }).required(), // connection id
   paths: Joi.array().items(Joi.object({
     ...CONTENT_PATH,
-    recipients: Joi.array().items(RECIPIENT).min(1).optional(),
+    recipients: Joi.array().items(RECIPIENT).min(1),
     error: Joi.object({
       message: Joi.string().required(),
-      status: Joi.number().integer().min(400).max(599).optional(),
-      code: Joi.string().optional(),
-      stack: Joi.string().optional()
+      status: Joi.number().integer().min(400).max(599),
+      code: Joi.string(),
+      stack: Joi.string()
     })
-  })).min(1).optional()
+  })).min(1)
 })
 
 // app -> operator
@@ -301,8 +300,8 @@ const RECIPIENTS_WRITE = Joi.object({
   sub: Joi.string().uuid({ version: 'uuidv4' }).required(), // connection id
   paths: Joi.array().items(Joi.object({
     ...CONTENT_PATH,
-    recipients: Joi.array().items(RECIPIENT).min(1).optional()
-  })).min(1).optional()
+    recipients: Joi.array().items(RECIPIENT).min(1)
+  })).min(1)
 }).required()
 
 // Schemas used from mobile device allowing jwk in payload


### PR DESCRIPTION
This PR adds a delete consent schema for the device, so that the user can tell the operator he wishes for a consent to be removed. 

Also enforced length of "denied", in CONNECTION schema, to be atleast one, if this field is included.

This PR also removes some .optional() (since that is the default behaviour)